### PR TITLE
Linux compatibility for ptcGraph examples

### DIFF
--- a/Examples/freepascal/resdemos/fpresdemo1.pas
+++ b/Examples/freepascal/resdemos/fpresdemo1.pas
@@ -2,7 +2,11 @@
 // see video for example usage
 
 Program fpresdemo1;
-    uses  ptccrt,ptcgraph;
+  uses
+  {$ifdef Linux}
+  cthreads,
+  {$endif}
+  ptccrt,ptcgraph;
 
 const
 {$I shapes.inc}
@@ -26,7 +30,7 @@ begin
 end;
 
 var
- gd,gm : integer;
+ gd,gm : smallint;
 
 begin
  gd:=VGA;

--- a/Examples/freepascal/resdemos/fpresdemo2.pas
+++ b/Examples/freepascal/resdemos/fpresdemo2.pas
@@ -5,17 +5,21 @@
 // see video for example usage
 
 Program fpresdemo2;
-  uses  ptccrt,ptcgraph;
+  uses
+  {$ifdef Linux}
+  cthreads,
+  {$endif}
+  ptccrt,ptcgraph;
 
 type
  reshead = packed Record
             sig : array[1..3] of char;
             ver : byte;
-            resitemcount: integer;
+            resitemcount: smallint;
            end;
 
  resrec = packed Record
-             rt     : integer;
+             rt     : smallint;
              rid    : array[1..20] of char;
              offset : longint;
              size   : longint;
@@ -51,7 +55,7 @@ end;
 
 procedure DelSpaces(var s : string);
 begin
- while s[length(s)]=#32 do
+ while (length(s)>0) and (s[length(s)]=#32) do
  begin
    delete(s,length(s),1);
  end;
@@ -130,7 +134,7 @@ begin
 end;
 
 var
- gd,gm : integer;
+ gd,gm : smallint;
 
 begin
  gd:=VGA;


### PR DESCRIPTION
These modifications make the ptcGraph examples compatible with Linux, and allow to compile them without the **-Mtp** option.
